### PR TITLE
Update "About" page to support new Discord usernames

### DIFF
--- a/about.php
+++ b/about.php
@@ -34,35 +34,35 @@
     <div class="ribbon">
         <div class="user">
             <img class="userimage" src="<?php echo getUser(839237573595365406)['avatar'] ?>">
-            <span class="name"><?php echo getUser(839237573595365406)['name'] ?></header>
+            <span class="name"><?php echo getUser(839237573595365406)['name'] ?><br><?php echo getUser(839237573595365406)['username']; ?></header>
         </div>
         <div class="user">
             <img class="userimage" src="<?php echo getUser(513072262409355274)['avatar'] ?>">
-            <span class="name"><?php echo getUser(513072262409355274)['name'] ?></header>
+            <span class="name"><?php echo getUser(513072262409355274)['name'] ?><br><?php echo getUser(513072262409355274)['username']; ?></header>
         </div>
         <div class="user">
             <img class="userimage" src="<?php echo getUser(341988909363757057)['avatar'] ?>">
-            <span class="name"><?php echo getUser(341988909363757057)['name']; ?></header>
+            <span class="name"><?php echo getUser(341988909363757057)['name']; ?><br><?php echo getUser(341988909363757057)['username']; ?></header>
         </div>
         <div class="user">
             <img class="userimage" src="<?php echo getUser(104933285506908160)['avatar'] ?>">
-            <span class="name"><?php echo getUser(104933285506908160)['name'] ?></header>
+            <span class="name"><?php echo getUser(104933285506908160)['name'] ?><br><?php echo getUser(104933285506908160)['username']; ?></header>
         </div>
         <div class="user">
             <img class="userimage" src="<?php echo getUser(715898328973574185)['avatar'] ?>">
-            <span class="name"><?php echo getUser(715898328973574185)['name'] ?></header>
+            <span class="name"><?php echo getUser(715898328973574185)['name'] ?><br><?php echo getUser(715898328973574185)['username']; ?></header>
         </div>
         <div class="user">
             <img class="userimage" src="<?php echo getUser(820255805257023498)['avatar'] ?>">
-            <span class="name"><?php echo getUser(820255805257023498)['name'] ?></header>
+            <span class="name"><?php echo getUser(820255805257023498)['name'] ?><br><?php echo getUser(820255805257023498)['username']; ?></header>
         </div>
         <div class="user">
             <img class="userimage" src="<?php echo getUser(912852147392102421)['avatar'] ?>">
-            <span class="name"><?php echo getUser(912852147392102421)['name'] ?></header>
+            <span class="name"><?php echo getUser(912852147392102421)['name'] ?><br><?php echo getUser(912852147392102421)['username']; ?></header>
         </div>
         <div class="user">
             <img class="userimage" src="<?php echo getUser(584672380085862407)['avatar'] ?>">
-            <span class="name"><?php echo getUser(584672380085862407)['name'] ?></header>
+            <span class="name"><?php echo getUser(584672380085862407)['name'] ?><br><?php echo getUser(584672380085862407)['username']; ?></header>
         </div>
     </div>
 </body>

--- a/scripts/php/discordusers.php
+++ b/scripts/php/discordusers.php
@@ -31,10 +31,15 @@ function getUser(int $id): array
         if (!$json_decode['id']) {
             echo "<script> console.error('API callback failed. Key might be expired or not provided correctly.') </script>";
         } else {
-            $username = $json_decode['username'];
-            $username .= "#";
-            $username .= $json_decode['discriminator'];
-
+            if ($json_decode['display_name'] != null) {
+                $username = $json_decode['display_name'];
+                $pomelousername = "(@" . $json_decode['username'] . ")";
+            } else {
+                $username = $json_decode['username'];
+                $username .= "#";
+                $username .= $json_decode['discriminator'];
+                $pomelousername = "";
+            };
             if ($json_decode['avatar']) {
                 $avatar = 'https://cdn.discordapp.com/avatars/' . $id . '/' . $json_decode['avatar'] . '?size=2048';
             }
@@ -42,6 +47,7 @@ function getUser(int $id): array
     }
     return array(
         "name" => $username,
-        "avatar" => $avatar
+        "avatar" => $avatar,
+        "username" => $pomelousername
     );
 }


### PR DESCRIPTION
![image](https://github.com/BlueAtomic/Forum-software/assets/55001472/79e909c6-5f96-4e1f-8131-2684135858fc)
As you can see in the image, it shows only the name#0000 if the user has a legacy username with a discriminator. If the user has a new "pomelo" (Discord's internal name) username, it will instead show their display name in the first line, and their unique username in the second line